### PR TITLE
Updated dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 # It is not meant to be published, but is used so "cargo run --example XYZ" works properly
 [package]
 name = "dioxus-example-projects"
-version = "0.0.0"
+version = "0.0.1"
 edition = "2021"
 description = "Top level crate for the Dioxus examples repository"
 authors = ["Jonathan Kelley"]

--- a/dog-app/Cargo.toml
+++ b/dog-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dog-app"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Search the Dog CEO API for your favorite doggo"
 license = "MIT/Apache-2.0"
@@ -10,15 +10,15 @@ documentation = "https://dioxuslabs.com"
 keywords = ["dom", "ui", "gui", "react", "wasm"]
 
 [dependencies]
-dioxus = "0.3"
-dioxus-desktop = "0.3"
+dioxus = "0.4.0"
+dioxus-desktop = "0.4.0"
 reqwest = { version = "0.11.8", features = ["json"] }
 serde = { version = "1.0.132", features = ["derive"] }
 
 [package.metadata.bundle]
 name = "Dog Search Engine"
 identifier = "com.jon.dogsearch"
-version = "1.0.0"
+version = "1.0.1"
 copyright = "Copyright (c) Jane Doe 2016. All rights reserved."
 category = "Developer Tool"
 short_description = "An example application."

--- a/ecommerce-site/Cargo.toml
+++ b/ecommerce-site/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "ecommerce-site"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 axum = { version = "0.6.16", features = ["ws"] }
-cached = "0.43.0"
+cached = "0.44.0"
 dioxus = { git = "https://github.com/DioxusLabs/dioxus" }
 dioxus-ssr = { git = "https://github.com/DioxusLabs/dioxus" }
 dioxus-liveview = { git = "https://github.com/DioxusLabs/dioxus", features = ["axum"] }

--- a/file-explorer/Cargo.toml
+++ b/file-explorer/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "file-explorer"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 description = "File Explorer with Dioxus"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus = { version = "0.3" }
-dioxus-desktop = { version = "0.3" }
+dioxus = { version = "0.4.0" }
+dioxus-desktop = { version = "0.4.0" }
 log = "0.4.14"
-simple_logger = "1.13.0"
+simple_logger = "4.2.0"
 
 
 [package.metadata.bundle]

--- a/image_generator_open_ai/Cargo.toml
+++ b/image_generator_open_ai/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "image_generator_open_ai"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 
-dioxus = { version = "0.3" }
-dioxus-desktop = { version = "0.3" }
+dioxus = { version = "0.4.0" }
+dioxus-desktop = { version = "0.4.0" }
 reqwest = "0.11.13"
 tokio = { version = "1", features = ["full"] } 
 serde_json = "1.0.91"

--- a/ios_demo/Cargo.toml
+++ b/ios_demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dioxus-ios-demo"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Jonathan Kelley <jkelleyrtp@gmail.com>"]
 edition = "2018"
 
@@ -13,9 +13,9 @@ path = "gen/bin/desktop.rs"
 
 [dependencies]
 mobile-entry-point = "0.1.0"
-dioxus = { version = "0.3" }
-dioxus-mobile = { version = "0.3" }
-simple_logger = "1.11.0"
+dioxus = { version = "0.4.0" }
+dioxus-mobile = { version = "0.4.0" }
+simple_logger = "4.2.0"
 im-rc = "15.0.0"
 
 

--- a/jsframework-benchmark/Cargo.toml
+++ b/jsframework-benchmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsframework-benchmark"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -12,5 +12,5 @@ wasm-bindgen = { version = "0.2.79", features = ["enable-interning"] }
 
 # for local iteration
 # dioxus = { path = "../../../dioxus", features = ["web"] }
-dioxus = { version = "0.3" }
-dioxus-web = { version = "0.3" }
+dioxus = { version = "0.4.0" }
+dioxus-web = { version = "0.4.0" }

--- a/todomvc/Cargo.toml
+++ b/todomvc/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "todomvc"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus = { version = "0.3" }
-dioxus-web = { version = "0.3" }
+dioxus = { version = "0.4.0" }
+dioxus-web = { version = "0.4.0" }
 wasm-logger = "0.2.0"
 wasm-bindgen = "0.2.78"
 log = "0.4.14"

--- a/weatherapp/Cargo.toml
+++ b/weatherapp/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "weatherapp"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]
 chrono = { version = "0.4.26", features = ["serde"] }
-dioxus = "0.3"
-dioxus-web = "0.3"
+dioxus = "0.4.0"
+dioxus-web = "0.4.0"
 reqwest = { version = "0.11.18", features = ["json"] }
 serde = "1.0.171"
 serde_json = "1.0.102"

--- a/wifi-scanner/Cargo.toml
+++ b/wifi-scanner/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "wifi-scanner"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1.0.52"
-pretty_env_logger = "0.4.0"
+pretty_env_logger = "0.5.0"
 tokio = { version = "1.12.0", features = ["full"] }
-dioxus = { version = "0.3" }
-dioxus-desktop = { version = "0.3" }
+dioxus = { version = "0.4.0" }
+dioxus-desktop = { version = "0.4.0" }
 wifiscanner = "0.5.1"
 futures-channel = "0.3.19"
 futures = "0.3.19"


### PR DESCRIPTION
This pr updates the dependencies of all the examples, so that they compile using the latest version of Dioxus. It partially fixes issue #37 and should also fix the problems preventing the merge of pull request  #41. Here is the status:
-  dog-app, ecommerce-site, and file-explorer work correctly
- I couldn't test properly  image_generator_open_ai and ios_demo, as I don't have an OpenAI API key and I don't own an iOS device. I can tell that the former compiles and starts correctly though.
- wifi-scanner compiles and starts correctly, but is unable to find WiFi networks. But maybe it needs to run with root privileges.
- jsframework-benchmark, todomvc, and weatherapp compile fine but then crash at runtime with the following error: `thread 'main' panicked at 'cannot call wasm-bindgen imported functions on non-wasm targets'`. I will not attempt to fix this though, so someone else would have to look into fixing these examples.

As a side note, it would probably be better to reorganize this repo in the future, so that the examples can be updated to new Dioxus versions separately, instead of forcing one to update all of them at the same time.